### PR TITLE
Fix docs & packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ It must be shared with your service account. Otherwise, your app will silently c
 ### 7. 🧪 Run the app
 
 ```bash
-python app.py
+python main.py
 ```
 
 A glorious little window will open, scraping job listings and extracting info while you sip your cold brew and question your life choices.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "gpt-powered-application-tracker"
 version = "0.1.0"
 description = "GPT-Powered Application Tracker is a Python application that uses OpenAI's GPT model to track job applications, providing a user-friendly interface and integration with Google Sheets for data storage."
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.9"
 dependencies = [
     "bs4>=0.0.2",
     "flet[all]==0.28.3",


### PR DESCRIPTION
## Summary
- fix README run command to use `main.py`
- lower required Python version in `pyproject.toml`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6842ac7b8800832f9339795d6e16de6d